### PR TITLE
Specify a directory instead of a file for the logstash configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ docker run -p 8080:80 \
 Then, browse: [http://localhost:8080](http://localhost:8080) (replace
 `localhost` with your public IP address).
 
-Your logstash configuration directory MUST contain a `logstash.conf` file.
+Your logstash configuration directory MUST contain at least one logstash configuration file. If several files are found in the configuration directory, logstash will use all of them, concatenated in lexicographical order, as the configuration.
 
 ### Fig Configuration
 

--- a/etc/supervisor/conf.d/logstash.conf
+++ b/etc/supervisor/conf.d/logstash.conf
@@ -1,4 +1,4 @@
 [program:logstash]
-command=/opt/logstash/bin/logstash agent -f /etc/logstash/logstash.conf
+command=/opt/logstash/bin/logstash agent -f /etc/logstash/
 stdout_logfile=/var/log/logstash/stdout.log
 redirect_stderr=true


### PR DESCRIPTION
I'm using your docker image to analyze logs from various inputs (file, udp.. not only lumberjack). I find it convenient to edit my configuration in multiple files. It's possible to specify a directory instead of a file for the logstash configuration (I found this thread -> https://groups.google.com/forum/#!topic/logstash-users/eNYmpFueHtM)
Could you consider this PR? Thanks!