### PR TITLE
import elasticsearch signing key from keyserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ MAINTAINER William Durand <william.durand1@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update
-RUN apt-get install -y supervisor curl wget
+RUN apt-get install -y supervisor curl
 
 # Elasticsearch
 RUN \
-    wget -qO - http://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add - && \
+    apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4 && \
     if ! grep "elasticsearch" /etc/apt/sources.list; then echo "deb http://packages.elasticsearch.org/elasticsearch/1.4/debian stable main" >> /etc/apt/sources.list;fi && \
     if ! grep "logstash" /etc/apt/sources.list; then echo "deb http://packages.elasticsearch.org/logstash/1.4/debian stable main" >> /etc/apt/sources.list;fi && \
     apt-get update


### PR DESCRIPTION
Instead of a direct download from unsecure source.
As done into the official Elasticsearch docker file (https://github.com/docker-library/elasticsearch/blob/master/1.4/Dockerfile#L3)