### PR TITLE
Do not install recommanded packages and use logstash 1.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER William Durand <william.durand1@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update
-RUN apt-get install -y supervisor curl
+RUN apt-get install --no-install-recommends -y supervisor curl
 
 # Elasticsearch
 RUN \
@@ -14,7 +14,7 @@ RUN \
     apt-get update
 
 RUN \
-    apt-get install -y elasticsearch && \
+    apt-get install --no-install-recommends -y elasticsearch && \
     apt-get clean && \
     sed -i '/#cluster.name:.*/a cluster.name: logstash' /etc/elasticsearch/elasticsearch.yml && \
     sed -i '/#path.data: \/path\/to\/data/a path.data: /data' /etc/elasticsearch/elasticsearch.yml
@@ -22,7 +22,7 @@ RUN \
 ADD etc/supervisor/conf.d/elasticsearch.conf /etc/supervisor/conf.d/elasticsearch.conf
 
 # Logstash
-RUN apt-get install -y logstash logstash-contrib && \
+RUN apt-get install --no-install-recommends -y logstash logstash-contrib && \
     apt-get clean
 
 ADD etc/supervisor/conf.d/logstash.conf /etc/supervisor/conf.d/logstash.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install --no-install-recommends -y supervisor curl
 RUN \
     apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 46095ACC8548582C1A2699A9D27D666CD88E42B4 && \
     if ! grep "elasticsearch" /etc/apt/sources.list; then echo "deb http://packages.elasticsearch.org/elasticsearch/1.4/debian stable main" >> /etc/apt/sources.list;fi && \
-    if ! grep "logstash" /etc/apt/sources.list; then echo "deb http://packages.elasticsearch.org/logstash/1.4/debian stable main" >> /etc/apt/sources.list;fi && \
+    if ! grep "logstash" /etc/apt/sources.list; then echo "deb http://packages.elasticsearch.org/logstash/1.5/debian stable main" >> /etc/apt/sources.list;fi && \
     apt-get update
 
 RUN \
@@ -22,10 +22,13 @@ RUN \
 ADD etc/supervisor/conf.d/elasticsearch.conf /etc/supervisor/conf.d/elasticsearch.conf
 
 # Logstash
-RUN apt-get install --no-install-recommends -y logstash logstash-contrib && \
+RUN apt-get install --no-install-recommends -y logstash && \
     apt-get clean
 
 ADD etc/supervisor/conf.d/logstash.conf /etc/supervisor/conf.d/logstash.conf
+
+# Logstash plugins
+RUN /opt/logstash/bin/plugin install logstash-filter-translate
 
 # Kibana
 RUN \


### PR DESCRIPTION
This PR does two things (I can split this PR if you want):
* it avoids installing recommanded packages
* it upgrades Logstash to the 1.5 version

*Note*: the [way plugins are managed](https://www.elastic.co/blog/plugin-ecosystem-changes) changed with this release. I installed `logstash-filter-translate` but some users might need other plugins. Do you want to include more plugins by default?