### PR TITLE
Changed ENV setting of DEBIAN_FRONTEND to use ARG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM java:8
 MAINTAINER William Durand <william.durand1@gmail.com>
 
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y supervisor curl && \


### PR DESCRIPTION
This allows users to connect interactively if desired:
  docker run -ti

ARG is scoped to build time while ENV is set into the built image.

For more info:
https://github.com/docker/docker/issues/4032#issuecomment-192327844

https://docs.docker.com/engine/reference/builder/#arg